### PR TITLE
Update 104_LoRa_Receiver_Detailed_Setup_ESP32.ino

### DIFF
--- a/examples/SX126x_examples/ESP32/Basics/104_LoRa_Receiver_Detailed_Setup_ESP32/104_LoRa_Receiver_Detailed_Setup_ESP32.ino
+++ b/examples/SX126x_examples/ESP32/Basics/104_LoRa_Receiver_Detailed_Setup_ESP32/104_LoRa_Receiver_Detailed_Setup_ESP32.ino
@@ -189,7 +189,7 @@ void setup()
     digitalWrite(BUZZER, LOW);
   }
 
-  SPI.begin();
+  SPI.begin(SCK, MISO, MOSI, NSS);
 
   //SPI beginTranscation is normally part of library routines, but if it is disabled in the library
   //a single instance is needed here, so uncomment the program line below


### PR DESCRIPTION
SPI does not initialize correctly without adding the global variables to SPI.begin() on some custom boards with different default SPI pin mappings. Tested using bare ESP32-WROOM 32 module. Original code fails when using Board: "Silicognition wESP32". Above change fixes for all boards.