### PR TITLE
ADD: quick RSSI sampling.

### DIFF
--- a/src/SX126XLT.cpp
+++ b/src/SX126XLT.cpp
@@ -525,7 +525,7 @@ void SX126XLT::readCommand(uint8_t Opcode, uint8_t *buffer, uint16_t size)
 
   digitalWrite(_NSS, LOW);
   SPI.transfer(Opcode);
-  SPI.transfer(0xFF);
+  SPI.transfer(0xFF); // often with status answers
 
   for ( i = 0; i < size; i++ )
   {
@@ -1889,6 +1889,20 @@ uint8_t SX126XLT::receiveIRQ(uint8_t *rxbuffer, uint8_t size, uint16_t timeout, 
   return _RXPacketL;
 }
 
+int8_t SX126XLT::readInstaRSSI()
+{
+#ifdef SX126XDEBUG
+  Serial.println(F("readInstaRSSI()"));
+#endif
+
+  uint8_t rssi_raw;
+  int16_t rssi;
+
+  readCommand(RADIO_GET_RSSIINST, &rssi_raw, 1) ;
+  rssi = -rssi_raw / 2;
+
+  return rssi;
+}
 
 int16_t SX126XLT::readPacketRSSI()
 {

--- a/src/SX126XLT.h
+++ b/src/SX126XLT.h
@@ -81,6 +81,7 @@ class SX126XLT  {
     uint16_t CRCCCITT(uint8_t *buffer, uint32_t size, uint16_t start);
     uint8_t receive(uint8_t *rxbuffer, uint8_t size, uint32_t rxtimeout, uint8_t wait);
     uint8_t receiveIRQ(uint8_t *rxbuffer, uint8_t size, uint16_t timeout, uint8_t wait);
+    int8_t readInstaRSSI();
     int16_t readPacketRSSI();
     int8_t readPacketSNR();
     uint8_t readRXPacketL();


### PR DESCRIPTION
Hi Stuart,

while looking for a fast way to get activity metering on a selected frequency i found some already defined commands in your library definitions (RADIO_GET_RSSIINST, RADIO_SET_CAD), but just no API function for it.

I've just added one for now.
How do you think about integrating it to your library? The CAD part seems to be more effort, but would it be good to add this function as well?

Best regards

Thomas